### PR TITLE
fix(Table): Infinite scroll detection was broken

### DIFF
--- a/src/components/Table/KitTable.vue
+++ b/src/components/Table/KitTable.vue
@@ -156,6 +156,11 @@ export default {
     this.createObserver()
     this.setupDragRows()
   },
+  beforeDestroy() {
+    if (this.observer) {
+      this.observer.disconnect()
+    }
+  },
   methods: {
     onRowClick(row, event) {
       this.$emit('row-click', {
@@ -168,7 +173,9 @@ export default {
         this.observer.unobserve(this.$refs['infinite-scroll-loader'])
       }
       this.observer = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting) {
+        // TODO: investigate why we got some case of twice the same element in the
+        // entries. Seems to be related to the change of size of the observed element
+        if (entries.some(({ isIntersecting }) => isIntersecting)) {
           this.tableBottomReached()
         }
       })


### PR DESCRIPTION
There is still an interogation on why this fix is needed.

The observer callback gets 2 entries instead of one. The first relates
to an element of no size.

This might be a render issue.