### PR TITLE
chore: handle correctly dragging when there are undraggable elements

### DIFF
--- a/src/components/common/KitDraggable.js
+++ b/src/components/common/KitDraggable.js
@@ -84,7 +84,9 @@ export default Vue.extend({
   },
   mounted() {
     if (this.enabled) {
-      this.setupDrag()
+      setTimeout(() => {
+        this.setupDrag()
+      }, 500)
     }
   },
 
@@ -150,28 +152,37 @@ export default Vue.extend({
     },
     onDragOver(event) {
       const target = closest(event.target, this.draggableClass)
+      const parent = target.parentNode
 
       if (!target || !this.itemsList.includes(target)) {
-        return
-      }
-      clearTimeout(this.timerToRemoveGhost)
-
-      const parent = target.parentNode
-      const index = this.itemsList.indexOf(target)
-
-      if (index === this.draggedElementIndex) {
         try {
           parent.removeChild(this.ghostElement)
         } catch (e) {
           // ignore
         }
-      } else if (index < this.draggedElementIndex) {
+        return
+      }
+      clearTimeout(this.timerToRemoveGhost)
+
+      const siblings = Array.from(parent.childNodes)
+      const indexInItems = this.itemsList.indexOf(target)
+
+      const indexInSiblings = siblings.indexOf(target)
+      if (indexInItems === this.draggedElementIndex) {
+        try {
+          parent.removeChild(this.ghostElement)
+        } catch (e) {
+          // ignore
+        }
+      } else if (indexInItems < this.draggedElementIndex) {
+        // add on left of element
         parent.insertBefore(this.ghostElement, target)
       } else {
-        if (index === this.itemsList.length - 1) {
+        // add on right of element
+        if (indexInSiblings === siblings.length - 1) {
           parent.append(this.ghostElement)
         } else {
-          parent.insertBefore(this.ghostElement, this.itemsList[index + 1])
+          parent.insertBefore(this.ghostElement, siblings[indexInSiblings + 1])
         }
       }
     },

--- a/stories/Tabs/Tabs.story.vue
+++ b/stories/Tabs/Tabs.story.vue
@@ -25,6 +25,9 @@
         <KitTabHeader class="demo-draggable" v-for="i in tabs" :id="i" :key="i" :disabled="i === 4">
           <span>Tab {{ i }}</span>
         </KitTabHeader>
+        <KitTabHeader id="cog">
+          <KitIcon type="cog" />
+        </KitTabHeader>
       </KitTabHeaders>
       <KitTabPanels>
         <KitTabPanel v-for="i in tabs" :id="i" :key="i">


### PR DESCRIPTION
In Tabs, we might have Tabs that are not draggable and that we need to ignore when dragging. This commit fixes the way we insert the drop zone in the list of items.