### PR TITLE
feat(KitMarkdownEditorRenderer): make is less obtrusive

### DIFF
--- a/src/components/Form/InlineEditViewContent.vue
+++ b/src/components/Form/InlineEditViewContent.vue
@@ -16,37 +16,36 @@
   </div>
 </template>
 
-<script>
-import KitIcon from '../Icon/KitIcon'
-import KitIconButton from '../Button/KitIconButton'
+<script setup lang="ts">
+import { ref } from 'vue'
+import KitIcon from '../Icon/KitIcon.vue'
+import KitIconButton from '../Button/KitIconButton.vue'
 
 const DRAG_THRESHOLD = 5
 
-export default {
-  name: 'KitInlineEditViewContent',
-  components: { KitIconButton, KitIcon },
-  data() {
-    return {
-      startX: 0,
-      startY: 0
-    }
-  },
-  methods: {
-    onMouseDown(e) {
-      this.startX = e.clientX
-      this.startY = e.clientY
-    },
-    onEnter() {
-      this.$emit('edit-requested')
-    },
-    onClick(e) {
-      if (this.mouseHasMoved(e)) return
-      this.$emit('edit-requested')
-    },
-    mouseHasMoved({ clientX, clientY }) {
-      return Math.abs(this.startX - clientX) >= DRAG_THRESHOLD || Math.abs(this.startY - clientY) >= DRAG_THRESHOLD
-    }
-  }
+const emit = defineEmits<{
+  (event: 'edit-requested')
+}>()
+
+const startX = ref(0)
+const startY = ref(0)
+
+function onMouseDown(e) {
+  startX.value = e.clientX
+  startY.value = e.clientY
+}
+
+function onEnter() {
+  emit('edit-requested')
+}
+
+function onClick(e) {
+  if (mouseHasMoved(e)) return
+  emit('edit-requested')
+}
+
+function mouseHasMoved({ clientX, clientY }) {
+  return Math.abs(startX.value - clientX) >= DRAG_THRESHOLD || Math.abs(startY.value - clientY) >= DRAG_THRESHOLD
 }
 </script>
 

--- a/src/components/MarkdownEditor/KitMarkdownEditor.vue
+++ b/src/components/MarkdownEditor/KitMarkdownEditor.vue
@@ -32,6 +32,7 @@ type Props = {
   minHeight?: number
   dontSanitize?: boolean
   autoFocus?: boolean
+  blurOnControlEnter?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -61,6 +62,7 @@ const emit = defineEmits<{
   (event: 'input', data: string)
   (event: 'blur', e: Event)
   (event: 'focus', e: Event)
+  (event: 'ctrl-enter')
 }>()
 
 const me = ref<HTMLDivElement>()
@@ -175,6 +177,12 @@ function onChange() {
 function onBlur() {
   emit('focus', new FocusEvent('blur'))
 }
+function onKeyUp(a, event: KeyboardEvent) {
+  if (event.ctrlKey && event.code === 'Enter') {
+    emit('ctrl-enter')
+    onBlur()
+  }
+}
 
 async function updateEditor(firstTime = false) {
   const cm = unref(editor)
@@ -192,9 +200,12 @@ async function updateEditor(firstTime = false) {
     cm.codemirror.on('change', onChange)
     cm.codemirror.on('focus', onFocus)
     cm.codemirror.on('blur', onBlur)
+    cm.codemirror.on('keyup', onKeyUp)
     if (props.autoFocus && firstTime) {
-      cm.codemirror.focus()
-      cm.codemirror.setCursor(cm.codemirror.lineCount(), 0)
+      setTimeout(() => {
+        cm.codemirror.focus()
+        cm.codemirror.setCursor(cm.codemirror.lineCount(), 0)
+      }, 250)
     }
   } else {
     await nextTick()
@@ -271,6 +282,7 @@ onUnmounted(() => {
   border-bottom: none;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
+  padding: 5px;
 }
 
 .kit-markdown-editor[data-has-status-bar='true'] >>> .editor-statusbar {

--- a/src/components/field-renderers/KitMarkdownEditableRenderer.vue
+++ b/src/components/field-renderers/KitMarkdownEditableRenderer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="kit-markdown-editable-renderer" style="padding: 10px 0" :data-disabled-ok="hasOkDisabled">
+  <div class="kit-markdown-editable-renderer" ref="containerRef" :data-disabled-ok="hasOkDisabled">
     <KitInlineEdit
       v-if="editable"
       :confirm="!allowBlurToSave"
@@ -7,20 +7,30 @@
       placement="top"
       :force-is-editing="forceIsEditing"
       :value="value"
+      :element-to-position-confirm-buttons-to="markdownEditorRef"
       @start-editing="onStartEditing"
       @stop-editing="onStopEditing"
       @save-requested="onSaveRequested">
       <template #editor="editProps">
-        <KitMarkdownEditor
-          auto-focus
-          :placeholder="placeholder"
-          :value="editProps.value"
-          :size-limit="sizeLimit"
-          :toolbar="toolbar"
-          :min-height="minHeight"
-          @input="onInput(editProps.input, $event)"
-          @focus="editProps.focus"
-          @blur="onBlur(editProps.blur, $event)" />
+        <div class="kit-markdown-editable-renderer__placeholder" ref="placeholderRef">&nbsp;</div>
+        <div class="kit-markdown-editable-renderer__editor-container" ref="markdownEditorRef">
+          <div class="kit-markdown-editable-renderer__editor">
+            <KitMarkdownEditor
+              auto-focus
+              :placeholder="placeholder"
+              :value="editProps.value"
+              :size-limit="sizeLimit"
+              :toolbar="toolbar"
+              :min-height="minHeight"
+              @ctrl-enter="onCtrlEnter(editProps.confirm)"
+              @input="onInput(editProps.input, $event)"
+              @focus="editProps.focus"
+              @blur="onBlur(editProps.blur, $event)" />
+          </div>
+          <div class="kit-markdown-editable-renderer__editor-buttons">
+            <KitButtonGroup> </KitButtonGroup>
+          </div>
+        </div>
       </template>
       <template #default>
         <slot>
@@ -39,7 +49,9 @@
 <script setup lang="ts">
 import KitMarkdownEditor, { ToolbarItem } from '@components/MarkdownEditor/KitMarkdownEditor.vue'
 import KitInlineEdit from '@components/Form/InlineEdit.vue'
-import { nextTick, ref } from 'vue'
+import { nextTick, onUnmounted, ref, watch } from 'vue'
+import KitButtonGroup from '@components/Button/KitButtonGroup.vue'
+import { convertNumbersToPx, findTableParent, setStyles } from '@/utils/dom'
 
 type Props = {
   value?: string
@@ -61,6 +73,9 @@ const props = withDefaults(defineProps<Props>(), {
 const isEditing = ref(false)
 const currentValue = ref(props.value)
 const hasOkDisabled = ref(false)
+const containerRef = ref<HTMLDivElement>()
+const markdownEditorRef = ref<HTMLDivElement>()
+const placeholderRef = ref<HTMLDivElement>()
 
 function contentClicked(evt: Event) {
   // link click should not trigger editing
@@ -89,14 +104,137 @@ function onBlur(originalOnBlur: (event: FocusEvent) => void, event: FocusEvent) 
   }
 }
 
+function onCtrlEnter(confirm) {
+  confirm()
+}
+
+function updateTable() {
+  const table = findTableParent(containerRef.value)
+  if (table) {
+    // let's fix the table column widths
+    const headerCell = table.querySelectorAll('thead th')
+    if (!headerCell || !headerCell.length) {
+      return
+    }
+
+    headerCell.forEach((cell: HTMLTableCellElement) => {
+      const box = cell.getBoundingClientRect()
+      if (cell.style.width) {
+        cell.dataset.kitpreviouswidth = cell.style.width
+      }
+      cell.style.width = `${box.width}px`
+    })
+  }
+}
+
+function cleanupTable() {
+  const table = findTableParent(containerRef.value)
+
+  if (table) {
+    const headerCell = table.querySelectorAll('thead th')
+    if (!headerCell || !headerCell.length) {
+      return
+    }
+
+    headerCell.forEach((cell: HTMLTableCellElement) => {
+      if (cell.dataset.kitpreviouswidth) {
+        cell.style.width = cell.dataset.kitpreviouswidth
+      } else {
+        cell.style.width = undefined
+      }
+    })
+  }
+}
+
+let observerHeight = 0
+const observer = new ResizeObserver((entries) => {
+  const height = entries[0].contentRect.height
+  if (height !== observerHeight) {
+    observerHeight = height
+    positionEditor()
+  }
+})
+
+async function positionEditor() {
+  if (!markdownEditorRef.value) {
+    await nextTick()
+    positionEditor()
+  } else {
+    document.body.appendChild(markdownEditorRef.value)
+
+    const box = placeholderRef.value.getBoundingClientRect()
+    const bodyBox = document.body.getBoundingClientRect()
+    const toolbar = markdownEditorRef.value.querySelector('.editor-toolbar') as HTMLDivElement
+
+    let editorContainerStyles: Partial<CSSStyleDeclaration> = {}
+
+    if (toolbar) {
+      toolbar.style.backgroundColor = 'white'
+
+      const isInTable = Boolean(findTableParent(containerRef.value))
+
+      const moveUp = toolbar.getBoundingClientRect().height + (isInTable ? 1 : 2)
+      const moveLeft = 2
+
+      editorContainerStyles = {
+        ...editorContainerStyles,
+        ...convertNumbersToPx({
+          // transform: `translate(${moveLeft}px, -${moveUp}px)`,
+          top: box.top - bodyBox.top - moveUp,
+          left: box.left - bodyBox.left - moveLeft,
+          width: width + 20
+        })
+      }
+
+      // text container height
+      setStyles(markdownEditorRef.value.querySelector('.CodeMirror-scroll') as HTMLDivElement, {
+        minHeight: `${props.minHeight ?? 25}px`
+      })
+
+      setStyles(markdownEditorRef.value, editorContainerStyles)
+    }
+  }
+}
+
+function cleanUp() {
+  cleanupTable()
+  document.body.removeChild(markdownEditorRef.value)
+}
+
+let height = 0
+let width = 0
+
+watch(isEditing, (editing) => {
+  if (editing) {
+    setStyles(placeholderRef.value, convertNumbersToPx({ height: height - 4, width }))
+    observer.observe(markdownEditorRef.value)
+    // We observe just the time the UI stabilizes (toolbar get final dimensions)
+    setTimeout(() => {
+      observer.disconnect()
+    }, 300)
+    positionEditor()
+  } else {
+    observer.disconnect()
+  }
+})
+
 async function onStartEditing() {
+  // This should run ASAP to fix the dimension of the columns
+  updateTable()
+
+  const box = containerRef.value.getBoundingClientRect()
+  height = box.height
+  width = box.width
   await nextTick()
   isEditing.value = true
+
   emit('start-editing')
 }
 
 function onStopEditing() {
   isEditing.value = false
+
+  cleanUp()
   emit('stop-editing')
 }
 
@@ -108,10 +246,32 @@ function onSaveRequested(value: string, callback) {
   hasPendingChanges.value = false
   emit('save-requested', value, callback)
 }
+
+onUnmounted(() => {
+  if (markdownEditorRef.value) {
+    document.body.removeChild(markdownEditorRef.value)
+  }
+  observer.disconnect()
+})
 </script>
 
 <style scoped>
+.kit-markdown-editable-renderer {
+  padding: 10px 0;
+}
 .kit-markdown-editable-renderer[data-disabled-ok='true'] >>> .kit-buttons-wrapper__ok {
   visibility: hidden;
+}
+.kit-markdown-editable-renderer__editor-container {
+  position: absolute;
+  isolation: isolate;
+  z-index: 1000;
+  box-sizing: border-box;
+  margin-bottom: 30px;
+}
+.kit-markdown-editable-renderer__editor {
+  background-color: white;
+  box-shadow: rgba(9, 30, 66, 0.25) 0 4px 8px -2px, rgba(9, 30, 66, 0.31) 0 0 1px;
+  box-sizing: border-box;
 }
 </style>

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -18,3 +18,42 @@ export function uniqueId() {
   uniqueBaseCounter += 1
   return `kit-id-${uniqueIdBase + uniqueBaseCounter}`
 }
+
+export function convertNumbersToPx(
+  from: Record<keyof Partial<CSSStyleDeclaration>, string | number>
+): Partial<CSSStyleDeclaration> {
+  const result: Partial<CSSStyleDeclaration> = {}
+  for (const fromKey in from) {
+    let style = from[fromKey]
+    if (typeof style === 'number') {
+      style = `${style}px`
+    }
+    result[fromKey] = style
+  }
+  return result
+}
+
+export function setStyles(element: HTMLElement, styles: Partial<CSSStyleDeclaration>) {
+  if (!element) {
+    return
+  }
+  for (const stylesKey in styles) {
+    const style = styles[stylesKey]
+    element.style[stylesKey] = style
+  }
+}
+
+export function findTableParent(element: HTMLElement): HTMLElement | null {
+  if (!element) {
+    return null
+  }
+  let walk: HTMLElement = element
+  while (walk !== document.body) {
+    if (walk.tagName === 'TABLE') {
+      return walk
+    } else {
+      walk = walk.parentElement
+    }
+  }
+  return null
+}

--- a/stories/InlineEdit/MarkdownEditor/MarkdownEditableRenderer.story.vue
+++ b/stories/InlineEdit/MarkdownEditor/MarkdownEditableRenderer.story.vue
@@ -14,11 +14,29 @@
       :toolbar="['bold', 'italic']"
       style="margin-bottom: 100px"
       @save-requested="onSaveRequested" />
+
+    <h5>In a table</h5>
+
+    <KitTable
+      style="margin-bottom: 30px; width: 200px"
+      :columns="[
+        { id: 'id', label: 'ID' },
+        { id: 'value', label: 'Value' }
+      ]"
+      :data="[
+        { id: '1', value: 'asdasdfasd' },
+        { id: '2', value: 'asdfasdf' }
+      ]">
+      <template #value="{ value }">
+        <KitMarkdownEditableRenderer :value="value" :size-limit="50" @save-requested="onSaveRequested" />
+      </template>
+    </KitTable>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import KitTable from '@components/Table/KitTable.vue'
 import KitMarkdownEditableRenderer from '../../../src/components/field-renderers/KitMarkdownEditableRenderer.vue'
 
 const text = ref(`# Description


### PR DESCRIPTION
When getting into edit mode, the layout changed and the location of the editable zone changed compared to the readonly rendering.

Also:

InlineEdit allows to specify to which element the buttons are aligned to.

Markdown Editor propagates the Control Enter keystroke enabling to use it as a save request.